### PR TITLE
Fix PHP 8.4 Implicitly marking parameter  as nullable is deprecated

### DIFF
--- a/src/Traits/HasComments.php
+++ b/src/Traits/HasComments.php
@@ -48,7 +48,7 @@ trait HasComments
      *
      * @return static
      */
-    public function comment(array $data, Model $creator, Model $parent = null)
+    public function comment(array $data, Model $creator, Model $parent)
     {
         $commentableModel = $this->commentableModel();
 
@@ -70,7 +70,7 @@ trait HasComments
      *
      * @return mixed
      */
-    public function updateComment($id, $data, Model $parent = null)
+    public function updateComment($id, $data, Model $parent)
     {
         $commentableModel = $this->commentableModel();
 


### PR DESCRIPTION
Fix PHP 8.4 Implicitly marking parameter  as nullable is deprecated