### PR TITLE
Allow nullable parent parameter in HasComments trait

### DIFF
--- a/src/Traits/HasComments.php
+++ b/src/Traits/HasComments.php
@@ -48,7 +48,7 @@ trait HasComments
      *
      * @return static
      */
-    public function comment(array $data, Model $creator, Model $parent)
+    public function comment(array $data, Model $creator, ?Model $parent)
     {
         $commentableModel = $this->commentableModel();
 
@@ -70,7 +70,7 @@ trait HasComments
      *
      * @return mixed
      */
-    public function updateComment($id, $data, Model $parent)
+    public function updateComment($id, $data, ?Model $parent)
     {
         $commentableModel = $this->commentableModel();
 


### PR DESCRIPTION
Fixes issue introduced when removing implicit nullable for PHP 8.4