### PR TITLE
upgrade package for Laravel 13 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel: ["12.*", "13.*"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache/files
+          key: ${{ runner.os }}-composer-${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.laravel }}-
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies for Laravel ${{ matrix.laravel }}
+        run: composer update --prefer-dist --no-interaction --no-progress --with-all-dependencies laravel/framework:${{ matrix.laravel }}
+
+      - name: Run test suite
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         "homepage": "https://coliving.com"
     }],
     "require": {
-        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "kalnoy/nestedset": "^6.0"
+        "php": "^8.3|^8.4",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "kalnoy/nestedset": "^6.0|7.0.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^6.2",
+        "orchestra/testbench": "^11.0",
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "7.*|8.*|9.*|10.*|11.*"
+        "phpunit/phpunit": "^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          failOnRisky="true"
-         failOnWarning="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
+         failOnWarning="true">
     <testsuites>
         <testsuite name="Laravel Commentable Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -13,19 +13,19 @@ declare(strict_types=1);
 
 namespace Artisanry\Tests\Commentable;
 
-use GrahamCampbell\TestBench\AbstractPackageTestCase;
+use Orchestra\Testbench\TestCase;
 
-abstract class AbstractTestCase extends AbstractPackageTestCase
+abstract class AbstractTestCase extends TestCase
 {
     /**
-     * Get the service provider class.
+     * Get package service providers.
      *
      * @param \Illuminate\Interfaces\Foundation\Application $app
      *
-     * @return string
+     * @return array<int, class-string>
      */
-    protected function getServiceProviderClass($app)
+    protected function getPackageProviders($app)
     {
-        return \Artisanry\Commentable\CommentableServiceProvider::class;
+        return [\Artisanry\Commentable\CommentableServiceProvider::class];
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Artisanry\Tests\Commentable;
 
-use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
-
 class ServiceProviderTest extends AbstractTestCase
 {
-    use ServiceProviderTrait;
+    public function testServiceProviderIsLoaded(): void
+    {
+        $this->assertTrue(
+            $this->app->providerIsLoaded(\Artisanry\Commentable\CommentableServiceProvider::class)
+        );
+    }
 }


### PR DESCRIPTION
Expand Illuminate constraints to include Laravel 13, migrate package tests to Orchestra Testbench v11, and add a CI matrix that validates both Laravel 12 and 13.

